### PR TITLE
Fix tmp table

### DIFF
--- a/libraries/Fuel_search.php
+++ b/libraries/Fuel_search.php
@@ -1418,9 +1418,6 @@ class Fuel_search extends Fuel_advanced_module {
 
 		// drop backup table
 		$this->CI->dbforge->drop_table($new_table_bak);
-
-		// drop temp table
-		$this->CI->dbforge->drop_table($tmp_table_name);
 	}
 
 	// --------------------------------------------------------------------

--- a/libraries/Fuel_search.php
+++ b/libraries/Fuel_search.php
@@ -217,13 +217,13 @@ class Fuel_search extends Fuel_advanced_module {
 			// clear out the entire index
 			if ($clear_all)
 			{
-				if (!$this->use_tmp_table)
+				if (!$this->config('use_tmp_table'))
 				{
 					$this->clear_all();
 				}
 
 				// set to temp table if TRUE and if $clear_all is set to TRUE so as to make the indexing not appear broken while indexing
-				if ($this->use_tmp_table)
+				if ($this->config('use_tmp_table'))
 				{
 					$this->create_temp_table();
 					$this->CI->search_model->set_table($this->temp_table_name());
@@ -281,7 +281,7 @@ class Fuel_search extends Fuel_advanced_module {
 			}
 
 			// set to temp table if TRUE and if $clear_all is set to TRUE so as to make the indexing not appear broken while indexing
-			if ($this->use_tmp_table AND $clear_all AND !empty($pages))
+			if ($this->config('use_tmp_table') AND $clear_all AND !empty($pages))
 			{
 				$this->CI->search_model->set_table($orig_table_name);
 				$this->switch_from_temp_table();


### PR DESCRIPTION
Two things related to tmp_table:

1. Read value of 'use_tmp_table' from config file
It takes property 'use_tmp_table' of Fuel_search which is always `TRUE`. Changed to read value for config file.

2. Skip removing tmp_table 
Method is trying to remove temporary table which has just been renamed two lines above. It results in database error: 
```
Database error: A Database Error Occurred

	Error Number: 1051
	Unknown table 'fuel_search_tmp'
	DROP TABLE `fuel_search_tmp`
```